### PR TITLE
fix a bug: the actual fan speed cannot be set to 0 on 3090 and 4090

### DIFF
--- a/coolgpus
+++ b/coolgpus
@@ -221,8 +221,11 @@ def assign(display, command):
     log_output(['nvidia-settings', '-a', command, '-c', display])
 
 def set_speed(display, target):
-    assign(display, '[gpu:0]/GPUFanControlState=1')
-    assign(display, '[fan:0]/GPUTargetFanSpeed='+str(int(target)))
+    if target<=1:
+        assign(display, '[gpu:0]/GPUFanControlState=0')
+    else:
+        assign(display, '[gpu:0]/GPUFanControlState=1')
+        assign(display, '[fan:0]/GPUTargetFanSpeed='+str(int(target)))
 
 def manage_fans(displays):
     """Launches an X server for each GPU, then continually loops over the GPU fans to set their speeds according


### PR DESCRIPTION
In my tests, fan speed did adjust as expected after the temperature of the graphics card increased, but when the graphics card stopped working, your code show that the fan speed was set to 0, but the nvidia-smi command showed that the actual speed remained around 30% and could not be lower. I find that when the fan control was set to automatic, nvidia will automatically slow the fan down to 0, this will solve the bug.